### PR TITLE
 Add target `all` and fix output, run whitespace cleanup

### DIFF
--- a/gobench.go
+++ b/gobench.go
@@ -1,43 +1,43 @@
 package main
 
 import (
-	"crypto/tls"
-	"flag"
-	"fmt"
+        "crypto/tls"
+        "flag"
+        "fmt"
         "io/ioutil"
-	"log"
-	"math"
-	"sort"
-	"strconv"
-	"sync"
-	"time"
+        "log"
+        "math"
+        "sort"
+        "strconv"
+        "sync"
+        "time"
 
-	driver "github.com/arangodb/go-driver"
-	"github.com/arangodb/go-driver/http"
-	"github.com/arangodb/go-driver/vst"
-	vstproto "github.com/arangodb/go-driver/vst/protocol"
+        driver "github.com/arangodb/go-driver"
+        "github.com/arangodb/go-driver/http"
+        "github.com/arangodb/go-driver/vst"
+        vstproto "github.com/arangodb/go-driver/vst/protocol"
 )
 
 // Book is the basic data structure used for tests
 type Book struct {
-	Key     string `json:"_key,omitempty"`
-	Title   string `json:"title"`
-	NoPages int    `json:"no_pages"`
+        Key     string `json:"_key,omitempty"`
+        Title   string `json:"title"`
+        NoPages int    `json:"no_pages"`
 }
 
 var (
-	nrConnections int           = 1
-	endpoint      string        = "http://127.0.0.1:8529"
-	testcase      string        = "postDocs"
-	nrRequests    int           = 1000
-	parallelism   int           = 1
-	delay         time.Duration = 0
-	cleanup       bool          = true
-	protocol      string        = "HTTP" // can be "VST" as well
-	usetls        bool          = false
-	username      string
-	password      string
-	outputFormat  string        = "console" // can be "csv"
+        nrConnections int           = 1
+        endpoint      string        = "http://127.0.0.1:8529"
+        testcase      string        = "postDocs"
+        nrRequests    int           = 1000
+        parallelism   int           = 1
+        delay         time.Duration = 0
+        cleanup       bool          = true
+        protocol      string        = "HTTP" // can be "VST" as well
+        usetls        bool          = false
+        username      string
+        password      string
+        outputFormat  string        = "console" // can be "csv"
         branch        string        = "unset"   // used for CSV output
 
         submittedRequests int       = 0         // the number of requests submitted
@@ -67,17 +67,17 @@ func logStats(name string, times []time.Duration) {
 // all timings are in microseconds
 //
 func logStatsCSV(name string, times []time.Duration) {
-	nr := len(times)
-	if nr == 0 {
-		return
-	}
-	sort.Slice(times, func(a, b int) bool {
-		return int64(times[a]) < int64(times[b])
-	})
-	var sum time.Duration
-	for _, d := range times {
-		sum += d
-	}
+        nr := len(times)
+        if nr == 0 {
+                return
+        }
+        sort.Slice(times, func(a, b int) bool {
+                return int64(times[a]) < int64(times[b])
+        })
+        var sum time.Duration
+        for _, d := range times {
+                sum += d
+        }
         var mean = (sum/time.Duration(nr)).Nanoseconds() / 1000
         var sqrdiff float64
         for _, d := range times {
@@ -85,7 +85,7 @@ func logStatsCSV(name string, times []time.Duration) {
                 sqrdiff += tmp * tmp
         }
         var stddev = math.Sqrt(sqrdiff / float64(nr))
-	fmt.Printf("%s,%v,%s,%v,%v,%v,%v,%.2f,%s\n",
+        fmt.Printf("%s,%v,%s,%v,%v,%v,%v,%.2f,%s\n",
                 branch,                                      // ArangoDB branch name
                 time.Now().Unix(),                           // Unix timestamp
                 name,                                        // test name
@@ -98,407 +98,407 @@ func logStatsCSV(name string, times []time.Duration) {
 }
 
 func logStatsConsole(name string, times []time.Duration) {
-	nr := len(times)
-	if nr == 0 {
-		return
-	}
-	sort.Slice(times, func(a, b int) bool {
-		return int64(times[a]) < int64(times[b])
-	})
-	var sum time.Duration
-	for _, d := range times {
-		sum += d
-	}
-	log.Printf("Statistics for %s:", name)
-	log.Printf("Samples : %d", nr)
-	log.Printf("Average : %v", sum/time.Duration(nr))
-	log.Printf("Median  : %v", times[nr/2])
-	log.Printf("90%%     : %v", times[(nr*90)/100])
-	log.Printf("99%%     : %v", times[(nr*99)/100])
-	log.Printf("99.9%%   : %v", times[(nr*999)/1000])
-	if nr >= 20 {
-		s := ""
-		for i := 0; i < 10; i++ {
-			s = s + fmt.Sprintf(" %v", times[i])
-		}
-		log.Printf("Smallest:%s", s)
-		s = ""
-		for i := 10; i > 0; i-- {
-			s = s + fmt.Sprintf(" %v", times[nr-i])
-		}
-		log.Printf("Largest:%s", s)
-	}
+        nr := len(times)
+        if nr == 0 {
+                return
+        }
+        sort.Slice(times, func(a, b int) bool {
+                return int64(times[a]) < int64(times[b])
+        })
+        var sum time.Duration
+        for _, d := range times {
+                sum += d
+        }
+        log.Printf("Statistics for %s:", name)
+        log.Printf("Samples : %d", nr)
+        log.Printf("Average : %v", sum/time.Duration(nr))
+        log.Printf("Median  : %v", times[nr/2])
+        log.Printf("90%%     : %v", times[(nr*90)/100])
+        log.Printf("99%%     : %v", times[(nr*99)/100])
+        log.Printf("99.9%%   : %v", times[(nr*999)/1000])
+        if nr >= 20 {
+                s := ""
+                for i := 0; i < 10; i++ {
+                        s = s + fmt.Sprintf(" %v", times[i])
+                }
+                log.Printf("Smallest:%s", s)
+                s = ""
+                for i := 10; i > 0; i-- {
+                        s = s + fmt.Sprintf(" %v", times[nr-i])
+                }
+                log.Printf("Largest:%s", s)
+        }
 }
 
 func doPostDocs(col driver.Collection) {
-	// Create documents
-	// Make nrRequests divisible by parallelism:
-	nrRequestsPerWorker := nrRequests / parallelism
-	nrRequests = nrRequestsPerWorker * parallelism
-	submittedRequests += nrRequests
-	times := make([]time.Duration, nrRequests, nrRequests)
-	wg := sync.WaitGroup{}
+        // Create documents
+        // Make nrRequests divisible by parallelism:
+        nrRequestsPerWorker := nrRequests / parallelism
+        nrRequests = nrRequestsPerWorker * parallelism
+        submittedRequests += nrRequests
+        times := make([]time.Duration, nrRequests, nrRequests)
+        wg := sync.WaitGroup{}
 
-	worker := func(innerTimes []time.Duration, initDelay time.Duration) {
-		time.Sleep(initDelay)
-		for i := 0; i < len(innerTimes); i++ {
-			startTime := time.Now()
-			book := Book{
-				Key:     "",
-				Title:   "Some small string",
-				NoPages: i,
-			}
-			_, err := col.CreateDocument(nil, book)
-			if err != nil {
-				log.Fatalf("Failed to create document: %v", err)
-			}
-			endTime := time.Now()
-			innerTimes[i] = endTime.Sub(startTime)
-			time.Sleep(delay)
-		}
-	}
+        worker := func(innerTimes []time.Duration, initDelay time.Duration) {
+                time.Sleep(initDelay)
+                for i := 0; i < len(innerTimes); i++ {
+                        startTime := time.Now()
+                        book := Book{
+                                Key:     "",
+                                Title:   "Some small string",
+                                NoPages: i,
+                        }
+                        _, err := col.CreateDocument(nil, book)
+                        if err != nil {
+                                log.Fatalf("Failed to create document: %v", err)
+                        }
+                        endTime := time.Now()
+                        innerTimes[i] = endTime.Sub(startTime)
+                        time.Sleep(delay)
+                }
+        }
 
-	for j := 0; j < parallelism; j++ {
-		wg.Add(1)
-		go func(jj int) {
-			defer wg.Done()
-			initTime := time.Duration(jj * int(delay) / parallelism)
-			// Give non-overlapping slices to the workers which together cover
-			// the whole of times:
-			worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
-				initTime)
-		}(j)
-	}
+        for j := 0; j < parallelism; j++ {
+                wg.Add(1)
+                go func(jj int) {
+                        defer wg.Done()
+                        initTime := time.Duration(jj * int(delay) / parallelism)
+                        // Give non-overlapping slices to the workers which together cover
+                        // the whole of times:
+                        worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
+                                initTime)
+                }(j)
+        }
 
-	wg.Wait()
-	logStats("create document ops", times)
+        wg.Wait()
+        logStats("create document ops", times)
 }
 
 func doSeedDocs(col driver.Collection) {
-	// Create documents with specific keys
-	// Make nrRequests divisible by parallelism:
-	nrRequestsPerWorker := nrRequests / parallelism
-	nrRequests = nrRequestsPerWorker * parallelism
-	submittedRequests += nrRequests
-	times := make([]time.Duration, nrRequests, nrRequests)
-	wg := sync.WaitGroup{}
+        // Create documents with specific keys
+        // Make nrRequests divisible by parallelism:
+        nrRequestsPerWorker := nrRequests / parallelism
+        nrRequests = nrRequestsPerWorker * parallelism
+        submittedRequests += nrRequests
+        times := make([]time.Duration, nrRequests, nrRequests)
+        wg := sync.WaitGroup{}
 
-	worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
-		time.Sleep(initDelay)
-		for i := 0; i < len(innerTimes); i++ {
-			startTime := time.Now()
-			book := Book{
-				Key:     "K" + strconv.Itoa(base+i),
-				Title:   "Some small string",
-				NoPages: i,
-			}
-			_, err := col.CreateDocument(nil, book)
-			if err != nil {
-				log.Fatalf("Failed to create document: %v", err)
-			}
-			endTime := time.Now()
-			innerTimes[i] = endTime.Sub(startTime)
-			time.Sleep(delay)
-		}
-	}
+        worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
+                time.Sleep(initDelay)
+                for i := 0; i < len(innerTimes); i++ {
+                        startTime := time.Now()
+                        book := Book{
+                                Key:     "K" + strconv.Itoa(base+i),
+                                Title:   "Some small string",
+                                NoPages: i,
+                        }
+                        _, err := col.CreateDocument(nil, book)
+                        if err != nil {
+                                log.Fatalf("Failed to create document: %v", err)
+                        }
+                        endTime := time.Now()
+                        innerTimes[i] = endTime.Sub(startTime)
+                        time.Sleep(delay)
+                }
+        }
 
-	for j := 0; j < parallelism; j++ {
-		wg.Add(1)
-		go func(jj int) {
-			defer wg.Done()
-			initTime := time.Duration(jj * int(delay) / parallelism)
-			// Give non-overlapping slices to the workers which together cover
-			// the whole of times:
-			worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
-				jj*nrRequestsPerWorker, initTime)
-		}(j)
-	}
+        for j := 0; j < parallelism; j++ {
+                wg.Add(1)
+                go func(jj int) {
+                        defer wg.Done()
+                        initTime := time.Duration(jj * int(delay) / parallelism)
+                        // Give non-overlapping slices to the workers which together cover
+                        // the whole of times:
+                        worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
+                                jj*nrRequestsPerWorker, initTime)
+                }(j)
+        }
 
-	wg.Wait()
-	logStats("seed document ops", times)
+        wg.Wait()
+        logStats("seed document ops", times)
 }
 
 func doReadDocs(col driver.Collection) {
-	// Read seeded documents with specific keys
-	// Make nrRequests divisible by parallelism:
-	nrRequestsPerWorker := nrRequests / parallelism
-	nrRequests = nrRequestsPerWorker * parallelism
-	submittedRequests += nrRequests
-	times := make([]time.Duration, nrRequests, nrRequests)
-	wg := sync.WaitGroup{}
+        // Read seeded documents with specific keys
+        // Make nrRequests divisible by parallelism:
+        nrRequestsPerWorker := nrRequests / parallelism
+        nrRequests = nrRequestsPerWorker * parallelism
+        submittedRequests += nrRequests
+        times := make([]time.Duration, nrRequests, nrRequests)
+        wg := sync.WaitGroup{}
 
-	worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
-		time.Sleep(initDelay)
-		for i := 0; i < len(innerTimes); i++ {
-			startTime := time.Now()
-			var book Book
-			key := "K" + strconv.Itoa(base+i)
-			if _, err := col.ReadDocument(nil, key, &book); err != nil {
-				log.Fatalf("Failed to read document: %v", err)
-			}
-			endTime := time.Now()
-			innerTimes[i] = endTime.Sub(startTime)
-			time.Sleep(delay)
-		}
-	}
+        worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
+                time.Sleep(initDelay)
+                for i := 0; i < len(innerTimes); i++ {
+                        startTime := time.Now()
+                        var book Book
+                        key := "K" + strconv.Itoa(base+i)
+                        if _, err := col.ReadDocument(nil, key, &book); err != nil {
+                                log.Fatalf("Failed to read document: %v", err)
+                        }
+                        endTime := time.Now()
+                        innerTimes[i] = endTime.Sub(startTime)
+                        time.Sleep(delay)
+                }
+        }
 
-	for j := 0; j < parallelism; j++ {
-		wg.Add(1)
-		go func(jj int) {
-			defer wg.Done()
-			initTime := time.Duration(jj * int(delay) / parallelism)
-			// Give non-overlapping slices to the workers which together cover
-			// the whole of times:
-			worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
-				jj*nrRequestsPerWorker, initTime)
-		}(j)
-	}
+        for j := 0; j < parallelism; j++ {
+                wg.Add(1)
+                go func(jj int) {
+                        defer wg.Done()
+                        initTime := time.Duration(jj * int(delay) / parallelism)
+                        // Give non-overlapping slices to the workers which together cover
+                        // the whole of times:
+                        worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
+                                jj*nrRequestsPerWorker, initTime)
+                }(j)
+        }
 
-	wg.Wait()
-	logStats("read document ops", times)
+        wg.Wait()
+        logStats("read document ops", times)
 }
 
 func doReadSameDocs(col driver.Collection) {
-	// Read always the same document
-	// Make nrRequests divisible by parallelism:
-	nrRequestsPerWorker := nrRequests / parallelism
-	nrRequests = nrRequestsPerWorker * parallelism
-	submittedRequests += nrRequests
-	times := make([]time.Duration, nrRequests, nrRequests)
-	wg := sync.WaitGroup{}
+        // Read always the same document
+        // Make nrRequests divisible by parallelism:
+        nrRequestsPerWorker := nrRequests / parallelism
+        nrRequests = nrRequestsPerWorker * parallelism
+        submittedRequests += nrRequests
+        times := make([]time.Duration, nrRequests, nrRequests)
+        wg := sync.WaitGroup{}
 
-	worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
-		time.Sleep(initDelay)
-		for i := 0; i < len(innerTimes); i++ {
-			startTime := time.Now()
-			var book Book
-			key := "K" + strconv.Itoa(base)
-			if _, err := col.ReadDocument(nil, key, &book); err != nil {
-				log.Fatalf("Failed to read document: %v", err)
-			}
-			endTime := time.Now()
-			innerTimes[i] = endTime.Sub(startTime)
-			time.Sleep(delay)
-		}
-	}
+        worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
+                time.Sleep(initDelay)
+                for i := 0; i < len(innerTimes); i++ {
+                        startTime := time.Now()
+                        var book Book
+                        key := "K" + strconv.Itoa(base)
+                        if _, err := col.ReadDocument(nil, key, &book); err != nil {
+                                log.Fatalf("Failed to read document: %v", err)
+                        }
+                        endTime := time.Now()
+                        innerTimes[i] = endTime.Sub(startTime)
+                        time.Sleep(delay)
+                }
+        }
 
-	for j := 0; j < parallelism; j++ {
-		wg.Add(1)
-		go func(jj int) {
-			defer wg.Done()
-			initTime := time.Duration(jj * int(delay) / parallelism)
-			// Give non-overlapping slices to the workers which together cover
-			// the whole of times:
-			worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
-				jj*nrRequestsPerWorker, initTime)
-		}(j)
-	}
+        for j := 0; j < parallelism; j++ {
+                wg.Add(1)
+                go func(jj int) {
+                        defer wg.Done()
+                        initTime := time.Duration(jj * int(delay) / parallelism)
+                        // Give non-overlapping slices to the workers which together cover
+                        // the whole of times:
+                        worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
+                                jj*nrRequestsPerWorker, initTime)
+                }(j)
+        }
 
-	wg.Wait()
-	logStats("read same document ops", times)
+        wg.Wait()
+        logStats("read same document ops", times)
 }
 
 func doReplaceDocs(col driver.Collection) {
-	// Will replace the seeded documents.
-	// Make nrRequests divisible by parallelism:
-	nrRequestsPerWorker := nrRequests / parallelism
-	nrRequests = nrRequestsPerWorker * parallelism
-	submittedRequests += nrRequests
-	times := make([]time.Duration, nrRequests, nrRequests)
-	wg := sync.WaitGroup{}
+        // Will replace the seeded documents.
+        // Make nrRequests divisible by parallelism:
+        nrRequestsPerWorker := nrRequests / parallelism
+        nrRequests = nrRequestsPerWorker * parallelism
+        submittedRequests += nrRequests
+        times := make([]time.Duration, nrRequests, nrRequests)
+        wg := sync.WaitGroup{}
 
-	worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
-		time.Sleep(initDelay)
-		for i := 0; i < len(innerTimes); i++ {
-			startTime := time.Now()
-			key := "K" + strconv.Itoa(base)
-			book := Book{
-				Key:     "K" + strconv.Itoa(base+i),
-				Title:   "Some small string",
-				NoPages: i,
-			}
-			if _, err := col.ReplaceDocument(nil, key, &book); err != nil {
-				log.Fatalf("Failed to replace document: %v", err)
-			}
-			endTime := time.Now()
-			innerTimes[i] = endTime.Sub(startTime)
-			time.Sleep(delay)
-		}
-	}
+        worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
+                time.Sleep(initDelay)
+                for i := 0; i < len(innerTimes); i++ {
+                        startTime := time.Now()
+                        key := "K" + strconv.Itoa(base)
+                        book := Book{
+                                Key:     "K" + strconv.Itoa(base+i),
+                                Title:   "Some small string",
+                                NoPages: i,
+                        }
+                        if _, err := col.ReplaceDocument(nil, key, &book); err != nil {
+                                log.Fatalf("Failed to replace document: %v", err)
+                        }
+                        endTime := time.Now()
+                        innerTimes[i] = endTime.Sub(startTime)
+                        time.Sleep(delay)
+                }
+        }
 
-	for j := 0; j < parallelism; j++ {
-		wg.Add(1)
-		go func(jj int) {
-			defer wg.Done()
-			initTime := time.Duration(jj * int(delay) / parallelism)
-			// Give non-overlapping slices to the workers which together cover
-			// the whole of times:
-			worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
-				jj*nrRequestsPerWorker, initTime)
-		}(j)
-	}
+        for j := 0; j < parallelism; j++ {
+                wg.Add(1)
+                go func(jj int) {
+                        defer wg.Done()
+                        initTime := time.Duration(jj * int(delay) / parallelism)
+                        // Give non-overlapping slices to the workers which together cover
+                        // the whole of times:
+                        worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
+                                jj*nrRequestsPerWorker, initTime)
+                }(j)
+        }
 
-	wg.Wait()
-	logStats("replace same document ops", times)
+        wg.Wait()
+        logStats("replace same document ops", times)
 }
 
 func doVersion(client driver.Client) {
-	// Create documents with specific keys
-	// Make nrRequests divisible by parallelism:
-	nrRequestsPerWorker := nrRequests / parallelism
-	nrRequests = nrRequestsPerWorker * parallelism
-	submittedRequests += nrRequests
-	times := make([]time.Duration, nrRequests, nrRequests)
-	wg := sync.WaitGroup{}
+        // Create documents with specific keys
+        // Make nrRequests divisible by parallelism:
+        nrRequestsPerWorker := nrRequests / parallelism
+        nrRequests = nrRequestsPerWorker * parallelism
+        submittedRequests += nrRequests
+        times := make([]time.Duration, nrRequests, nrRequests)
+        wg := sync.WaitGroup{}
 
-	worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
-		time.Sleep(initDelay)
-		for i := 0; i < len(innerTimes); i++ {
-			startTime := time.Now()
-			// _, err := client.Version(driver.WithDetails(nil, true))
-			_, err := client.Version(driver.WithDetails(nil, false))
-			if err != nil {
-				log.Fatalf("Error in /_api/version call: %v", err)
-			}
-			endTime := time.Now()
-			innerTimes[i] = endTime.Sub(startTime)
-			time.Sleep(delay)
-		}
-	}
+        worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
+                time.Sleep(initDelay)
+                for i := 0; i < len(innerTimes); i++ {
+                        startTime := time.Now()
+                        // _, err := client.Version(driver.WithDetails(nil, true))
+                        _, err := client.Version(driver.WithDetails(nil, false))
+                        if err != nil {
+                                log.Fatalf("Error in /_api/version call: %v", err)
+                        }
+                        endTime := time.Now()
+                        innerTimes[i] = endTime.Sub(startTime)
+                        time.Sleep(delay)
+                }
+        }
 
-	for j := 0; j < parallelism; j++ {
-		wg.Add(1)
-		go func(jj int) {
-			defer wg.Done()
-			initTime := time.Duration(jj * int(delay) / parallelism)
-			// Give non-overlapping slices to the workers which together cover
-			// the whole of times:
-			worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
-				jj*nrRequestsPerWorker, initTime)
-		}(j)
-	}
+        for j := 0; j < parallelism; j++ {
+                wg.Add(1)
+                go func(jj int) {
+                        defer wg.Done()
+                        initTime := time.Duration(jj * int(delay) / parallelism)
+                        // Give non-overlapping slices to the workers which together cover
+                        // the whole of times:
+                        worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
+                                jj*nrRequestsPerWorker, initTime)
+                }(j)
+        }
 
-	wg.Wait()
-	logStats("/_api/version", times)
+        wg.Wait()
+        logStats("/_api/version", times)
 }
 
 func doInitThreeDiamondAQL(client driver.Client) (driver.Database, driver.Collection) {
-	log.Printf("Setting up a database, collection and 100 documents...")
-	// Prepare a new books collection in some database:
-	db, err := client.Database(nil, "booksDB")
-	if err != nil {
-		// Create a database
-		db, err = client.CreateDatabase(nil, "booksDB", nil)
-		if err != nil {
-			log.Fatalf("Failed to create database: %v", err)
-		}
-	}
+        log.Printf("Setting up a database, collection and 100 documents...")
+        // Prepare a new books collection in some database:
+        db, err := client.Database(nil, "booksDB")
+        if err != nil {
+                // Create a database
+                db, err = client.CreateDatabase(nil, "booksDB", nil)
+                if err != nil {
+                        log.Fatalf("Failed to create database: %v", err)
+                }
+        }
 
-	// Create collection
-	col, err := db.Collection(nil, "books")
-	if err != nil {
-		col, err = db.CreateCollection(nil, "books", nil)
-		if err != nil {
-			log.Fatalf("Failed to create collection: %v", err)
-		}
-	} else {
-		col.Truncate(nil)
-	}
+        // Create collection
+        col, err := db.Collection(nil, "books")
+        if err != nil {
+                col, err = db.CreateCollection(nil, "books", nil)
+                if err != nil {
+                        log.Fatalf("Failed to create collection: %v", err)
+                }
+        } else {
+                col.Truncate(nil)
+        }
 
-	// Write some books:
-	for i := 0; i < 100; i++ {
-		book := Book{
-			Key:     "K" + strconv.Itoa(i),
-			Title:   "Some small string",
-			NoPages: i,
-		}
-		_, err := col.CreateDocument(nil, book)
-		if err != nil {
-			log.Fatalf("Failed to create document: %v", err)
-		}
-	}
+        // Write some books:
+        for i := 0; i < 100; i++ {
+                book := Book{
+                        Key:     "K" + strconv.Itoa(i),
+                        Title:   "Some small string",
+                        NoPages: i,
+                }
+                _, err := col.CreateDocument(nil, book)
+                if err != nil {
+                        log.Fatalf("Failed to create document: %v", err)
+                }
+        }
 
-	log.Printf("Done, let the race begin!")
-	return db, col
+        log.Printf("Done, let the race begin!")
+        return db, col
 }
 
 func doReadThreeDiamondAQL(db driver.Database, col driver.Collection) {
-	// Does a lot of three diamond AQL queries
-	// Make nrRequests divisible by parallelism:
-	nrRequestsPerWorker := nrRequests / parallelism
-	nrRequests = nrRequestsPerWorker * parallelism
-	submittedRequests += nrRequests
-	times := make([]time.Duration, nrRequests, nrRequests)
-	wg := sync.WaitGroup{}
+        // Does a lot of three diamond AQL queries
+        // Make nrRequests divisible by parallelism:
+        nrRequestsPerWorker := nrRequests / parallelism
+        nrRequests = nrRequestsPerWorker * parallelism
+        submittedRequests += nrRequests
+        times := make([]time.Duration, nrRequests, nrRequests)
+        wg := sync.WaitGroup{}
 
-	worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
-		time.Sleep(initDelay)
-		for i := 0; i < len(innerTimes); i++ {
-			startTime := time.Now()
-			var book Book
+        worker := func(innerTimes []time.Duration, base int, initDelay time.Duration) {
+                time.Sleep(initDelay)
+                for i := 0; i < len(innerTimes); i++ {
+                        startTime := time.Now()
+                        var book Book
 
-			// Get books by using AQL
-			cur, err := db.Query(nil, "FOR b1 IN books FOR b2 IN books FILTER b1._key == b2._key FOR b3 IN books FILTER b3._key == b1._key LIMIT 10 RETURN {_key: b1._key, title: b2.title, no_pages: b3.no_pages}", nil)
-			if err != nil {
-				log.Fatalf("Failed to ask for query cursor: %v", err)
-			}
-			for {
-				_, err = cur.ReadDocument(nil, &book)
-				if err != nil {
-					if driver.IsNoMoreDocuments(err) {
-						break
-					}
-					log.Fatalf("Failed to read doc from cursor: %v", err)
-				}
-			}
+                        // Get books by using AQL
+                        cur, err := db.Query(nil, "FOR b1 IN books FOR b2 IN books FILTER b1._key == b2._key FOR b3 IN books FILTER b3._key == b1._key LIMIT 10 RETURN {_key: b1._key, title: b2.title, no_pages: b3.no_pages}", nil)
+                        if err != nil {
+                                log.Fatalf("Failed to ask for query cursor: %v", err)
+                        }
+                        for {
+                                _, err = cur.ReadDocument(nil, &book)
+                                if err != nil {
+                                        if driver.IsNoMoreDocuments(err) {
+                                                break
+                                        }
+                                        log.Fatalf("Failed to read doc from cursor: %v", err)
+                                }
+                        }
 
-			endTime := time.Now()
-			innerTimes[i] = endTime.Sub(startTime)
-			time.Sleep(delay)
-		}
-	}
+                        endTime := time.Now()
+                        innerTimes[i] = endTime.Sub(startTime)
+                        time.Sleep(delay)
+                }
+        }
 
-	for j := 0; j < parallelism; j++ {
-		wg.Add(1)
-		go func(jj int) {
-			defer wg.Done()
-			initTime := time.Duration(jj * int(delay) / parallelism)
-			// Give non-overlapping slices to the workers which together cover
-			// the whole of times:
-			worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
-				jj*nrRequestsPerWorker, initTime)
-		}(j)
-	}
+        for j := 0; j < parallelism; j++ {
+                wg.Add(1)
+                go func(jj int) {
+                        defer wg.Done()
+                        initTime := time.Duration(jj * int(delay) / parallelism)
+                        // Give non-overlapping slices to the workers which together cover
+                        // the whole of times:
+                        worker(times[jj*nrRequestsPerWorker:(jj+1)*nrRequestsPerWorker],
+                                jj*nrRequestsPerWorker, initTime)
+                }(j)
+        }
 
-	wg.Wait()
-	logStats("read three diamond AQL ops", times)
-	if cleanup {
-		err := col.Remove(nil)
-		if err != nil {
-			log.Fatalf("Failed to drop collection: %v", err)
-		}
-		err = db.Remove(nil)
-		if err != nil {
-			log.Fatalf("Failed to drop database: %v", err)
-		}
-	}
+        wg.Wait()
+        logStats("read three diamond AQL ops", times)
+        if cleanup {
+                err := col.Remove(nil)
+                if err != nil {
+                        log.Fatalf("Failed to drop collection: %v", err)
+                }
+                err = db.Remove(nil)
+                if err != nil {
+                        log.Fatalf("Failed to drop database: %v", err)
+                }
+        }
 }
 
 func main() {
-	flag.IntVar(&nrConnections, "nrConnections", nrConnections, "number of connections")
-	flag.StringVar(&endpoint, "endpoint", endpoint, "server endpoint")
-	flag.StringVar(&testcase, "testcase", testcase, "test case")
-	flag.IntVar(&nrRequests, "nrRequests", nrRequests, "number of requests")
-	flag.IntVar(&parallelism, "parallelism", parallelism, "parallelism")
-	flag.DurationVar(&delay, "delay", delay, "delay per thread between operations")
-	flag.BoolVar(&cleanup, "cleanup", cleanup, "flag whether to perform cleanup")
-	flag.StringVar(&protocol, "protocol", protocol, "protocol: HTTP or VST")
-	flag.BoolVar(&usetls, "useTLS", usetls, "flag whether to use TLS")
-	flag.StringVar(&username, "auth.user", username, "Authentication Username")
-	flag.StringVar(&password, "auth.pass", password, "Authentication Password")
+        flag.IntVar(&nrConnections, "nrConnections", nrConnections, "number of connections")
+        flag.StringVar(&endpoint, "endpoint", endpoint, "server endpoint")
+        flag.StringVar(&testcase, "testcase", testcase, "test case")
+        flag.IntVar(&nrRequests, "nrRequests", nrRequests, "number of requests")
+        flag.IntVar(&parallelism, "parallelism", parallelism, "parallelism")
+        flag.DurationVar(&delay, "delay", delay, "delay per thread between operations")
+        flag.BoolVar(&cleanup, "cleanup", cleanup, "flag whether to perform cleanup")
+        flag.StringVar(&protocol, "protocol", protocol, "protocol: HTTP or VST")
+        flag.BoolVar(&usetls, "useTLS", usetls, "flag whether to use TLS")
+        flag.StringVar(&username, "auth.user", username, "Authentication Username")
+        flag.StringVar(&password, "auth.pass", password, "Authentication Password")
         flag.StringVar(&outputFormat, "outputFormat", outputFormat, "output format: console or csv")
         flag.StringVar(&branch, "branch", branch, "ArangoDB branch name for CSV output")
-	flag.Parse()
+        flag.Parse()
 
         if outputFormat != "console" && outputFormat != "csv" {
                 log.Fatalf("-outputFormat needs to be console or csv")
@@ -512,112 +512,112 @@ func main() {
         log.Printf("Server endpoint: %s using %d connections", endpoint, nrConnections)
         log.Println()
 
-	var conn driver.Connection
-	var err error
-	if protocol == "HTTP" {
-		connConfig := http.ConnectionConfig{
-			Endpoints: []string{endpoint},
-			ConnLimit: nrConnections,
-		}
-		if usetls {
-			connConfig.TLSConfig = &tls.Config{
-				InsecureSkipVerify: true,
-			}
-		}
-		conn, err = http.NewConnection(connConfig)
-		if err != nil {
-			log.Fatalf("Failed to create HTTP connection: %v", err)
-		}
-	} else if protocol == "VST" {
-		connConfig := vst.ConnectionConfig{
-			Endpoints: []string{endpoint},
-			Transport: vstproto.TransportConfig{
-				ConnLimit: nrConnections,
-			},
-		}
-		if usetls {
-			connConfig.TLSConfig = &tls.Config{
-				InsecureSkipVerify: true,
-			}
-		}
-		conn, err = vst.NewConnection(connConfig)
-		if err != nil {
-			log.Fatalf("Failed to create HTTP connection: %v", err)
-		}
-	} else {
-		log.Fatalf("-protocol needs to be HTTP or VST")
-	}
+        var conn driver.Connection
+        var err error
+        if protocol == "HTTP" {
+                connConfig := http.ConnectionConfig{
+                        Endpoints: []string{endpoint},
+                        ConnLimit: nrConnections,
+                }
+                if usetls {
+                        connConfig.TLSConfig = &tls.Config{
+                                InsecureSkipVerify: true,
+                        }
+                }
+                conn, err = http.NewConnection(connConfig)
+                if err != nil {
+                        log.Fatalf("Failed to create HTTP connection: %v", err)
+                }
+        } else if protocol == "VST" {
+                connConfig := vst.ConnectionConfig{
+                        Endpoints: []string{endpoint},
+                        Transport: vstproto.TransportConfig{
+                                ConnLimit: nrConnections,
+                        },
+                }
+                if usetls {
+                        connConfig.TLSConfig = &tls.Config{
+                                InsecureSkipVerify: true,
+                        }
+                }
+                conn, err = vst.NewConnection(connConfig)
+                if err != nil {
+                        log.Fatalf("Failed to create HTTP connection: %v", err)
+                }
+        } else {
+                log.Fatalf("-protocol needs to be HTTP or VST")
+        }
 
-	clientConfig := driver.ClientConfig{
-		Connection: conn,
-	}
+        clientConfig := driver.ClientConfig{
+                Connection: conn,
+        }
 
-	if username != "" {
-		clientConfig.Authentication = driver.BasicAuthentication(username, password)
-	}
+        if username != "" {
+                clientConfig.Authentication = driver.BasicAuthentication(username, password)
+        }
 
-	c, err := driver.NewClient(clientConfig)
+        c, err := driver.NewClient(clientConfig)
 
-	db, err := c.Database(nil, "benchDB")
-	if err != nil {
-		// Create a database
-		db, err = c.CreateDatabase(nil, "benchDB", nil)
-		if err != nil {
-			log.Fatalf("Failed to create database: %v", err)
-		}
-	}
+        db, err := c.Database(nil, "benchDB")
+        if err != nil {
+                // Create a database
+                db, err = c.CreateDatabase(nil, "benchDB", nil)
+                if err != nil {
+                        log.Fatalf("Failed to create database: %v", err)
+                }
+        }
 
-	// Create collection
-	col, err := db.Collection(nil, "test")
-	if err != nil {
-		col, err = db.CreateCollection(nil, "test", nil)
-		if err != nil {
-			log.Fatalf("Failed to create collection: %v", err)
-		}
-	}
+        // Create collection
+        col, err := db.Collection(nil, "test")
+        if err != nil {
+                col, err = db.CreateCollection(nil, "test", nil)
+                if err != nil {
+                        log.Fatalf("Failed to create collection: %v", err)
+                }
+        }
 
-	startTime := time.Now()
-	switch testcase {
-	case "postDocs":
-		doPostDocs(col)
-	case "seedDocs":
-		doSeedDocs(col)
-	case "readDocs":
-		doReadDocs(col)
-	case "readSameDocs":
-		doReadSameDocs(col)
-	case "replaceDocs":
-		doReplaceDocs(col)
-	case "readThreeDiamondAQL":
-		AQLdb, AQLcol := doInitThreeDiamondAQL(c)
-		startTime = time.Now()
-		doReadThreeDiamondAQL(AQLdb, AQLcol)
+        startTime := time.Now()
+        switch testcase {
+        case "postDocs":
+                doPostDocs(col)
+        case "seedDocs":
+                doSeedDocs(col)
+        case "readDocs":
+                doReadDocs(col)
+        case "readSameDocs":
+                doReadSameDocs(col)
+        case "replaceDocs":
+                doReplaceDocs(col)
+        case "readThreeDiamondAQL":
+                AQLdb, AQLcol := doInitThreeDiamondAQL(c)
+                startTime = time.Now()
+                doReadThreeDiamondAQL(AQLdb, AQLcol)
         case "all":
-		AQLdb, AQLcol := doInitThreeDiamondAQL(c)
-		startTime = time.Now()
+                AQLdb, AQLcol := doInitThreeDiamondAQL(c)
+                startTime = time.Now()
                 doPostDocs(col)
                 doSeedDocs(col)
                 doReadDocs(col)
                 doReadSameDocs(col)
                 doReplaceDocs(col)
-		doReadThreeDiamondAQL(AQLdb, AQLcol)
-	case "version":
-		doVersion(c)
-	}
-	endTime := time.Now()
+                doReadThreeDiamondAQL(AQLdb, AQLcol)
+        case "version":
+                doVersion(c)
+        }
+        endTime := time.Now()
 
         log.Println()
         log.Printf("Time for %d requests: %v", submittedRequests, endTime.Sub(startTime))
         log.Printf("Reqs/s: %d", int(float64(submittedRequests)/(float64(endTime.Sub(startTime))/1000000000.0)))
 
-	if cleanup {
-		err = col.Remove(nil)
-		if err != nil {
-			log.Fatalf("Failed to drop collection: %v", err)
-		}
-		err = db.Remove(nil)
-		if err != nil {
-			log.Fatalf("Failed to drop database: %v", err)
-		}
-	}
+        if cleanup {
+                err = col.Remove(nil)
+                if err != nil {
+                        log.Fatalf("Failed to drop collection: %v", err)
+                }
+                err = db.Remove(nil)
+                if err != nil {
+                        log.Fatalf("Failed to drop database: %v", err)
+                }
+        }
 }


### PR DESCRIPTION
 * the new test target `all` now runs all tests in succession; this is
   particularly useful when running with outputFormat csv for jenkins
 * fix the calculation of the standard deviation, as it turns out it
   suffered from an integer overflow which led to a square root of a
   negative number being computed (which is then printing as NaN).
 * to suppress pretty output when using csv output, we just direct
   the Logger output to the ioutil.Discard helper now which makes
   the code atiny bit cleaner
 * A separate commit runs whitespace-cleanup on the source replacing
  all tabs by spaces, because I have been caught out by the mix a couple of times now.